### PR TITLE
Get all of the storagetimes from the backend when adding new fridge item

### DIFF
--- a/front-end/src/ShoppingList/AddToFridgeItems.js
+++ b/front-end/src/ShoppingList/AddToFridgeItems.js
@@ -10,7 +10,7 @@ export function getSelectedCheckboxItems(name) {
   return values;
 }
 
-export function compileAddToFridgeItems() {
+export function compileAddToFridgeItems(storageitems) {
   let objects = [];
   // model object
   const foodItem = {
@@ -29,11 +29,30 @@ export function compileAddToFridgeItems() {
     add.title = vals[i].getAttribute("value");
     add.type = vals[i].getAttribute("food");
     add.amount = vals[i].getAttribute("amount");
-    add.dateadded = vals[i].getAttribute("date");
-    add.daysleft = 5; // PLACEHOLDER FOR FUTURE WHEN WE AUTOMATICALLLY PUT IN STORAGE TIME
+    add.dateadded = vals[i].getAttribute("date"); //April 1, 2021
+
+    try{
+      const findItem = storageitems.find(elem => elem.food === add.title)
+      add.daysleft = findItem.storage_time_medium;
+      } catch (e){
+        console.log("doesnt work!")
+        console.log(e);
+        console.log(add.type);
+        if (add.type == 1){
+          add.daysleft = 5;
+        }
+        else if (add.type == 2){
+          add.daysleft = 6;
+        }
+        else if (add.type == 3){
+          add.daysleft = 7;
+        }
+        else {
+          add.daysleft = 8;
+        }
+    }
     objects.push(add);
   }
-
   // returns array of objeccts of all items that are to be added
   return objects;
 }

--- a/front-end/src/ShoppingList/ShoppingList.js
+++ b/front-end/src/ShoppingList/ShoppingList.js
@@ -41,7 +41,15 @@ const ShoppingListView = (props) => {
 
   // Adding Items to Fridge and Deleting from Shopping List
   const onAddToFridge = async () => {
-    let AddData = compileAddToFridgeItems();
+    const [items, setItems] = useState(null)
+
+    const axiosResult = axios.get("/storagetimeitems")
+
+    axiosResult.then(response => {
+      setItems(...[response.data])
+    })
+
+    let AddData = compileAddToFridgeItems(items);
     await axios.post("/shopData/addToFridge", AddData);
     await axios.delete("/shopData", { data: AddData }).then((res) => {
       setShopData(res.data);


### PR DESCRIPTION
In Shopping List, when adding a new fridge item:
1. if that item exists in the backend data (which is currently hardcoded but will be synced soon), then it will take the medium storage time as its default.
2. If that item does not exist, then it will take the standard times for each food group (meats, dairy, grain ..etc.)